### PR TITLE
Replaced possible merge issues with a solution in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,11 @@ There are two methods for specifying the config options:
 
 #### Inline configuration
 
-Alternatively, you can add the configuration inline in your `docker-compose.yml` file like this:
+Alternatively, you can add the configuration inline in a `docker-compose.override.yml` file like this:
 
 ```yaml
 services:
   immich-person-to-album:
-    image: alangrainger/immich-person-to-album:latest
-    container_name: immich-person-to-album
-    restart: always
-    volumes:
-      - ./data:/data
     environment:
       CONFIG: |
         {
@@ -54,6 +49,7 @@ services:
           ]
         }
 ```
+That way, you can keep getting updates for the script, without having to merge any changes.
 
 ### Create an API key
 


### PR DESCRIPTION
When using a changed docker-compose.yml file, you can't update the repo, when using docker-compose.override.yml, you can actually do that. As the rest of the arguments will be retrieved from the primary file.